### PR TITLE
Add ConnectivityMonitor, Robolectric, Snackbar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,8 +57,8 @@ dependencies {
 
     // Test
     testCompile 'junit:junit:4.12'
-    testCompile "org.robolectric:robolectric:$roboelectric_version"
-    testCompile "org.robolectric:shadows-support-v4:$roboelectric_version"
+    testCompile "org.robolectric:robolectric:$robolectric_version"
+    testCompile "org.robolectric:shadows-support-v4:$robolectric_version"
 }
 
 repositories {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,15 +45,20 @@ kapt {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
-    testCompile 'junit:junit:4.12'
+    compile "com.android.support:appcompat-v7:$supportlib_version"
 
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile "com.android.support:design:$supportlib_version"
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
     // Dagger
     compile "com.google.dagger:dagger:$dagger_version"
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
+
+    // Test
+    testCompile 'junit:junit:4.12'
+    testCompile "org.robolectric:robolectric:$roboelectric_version"
+    testCompile "org.robolectric:shadows-support-v4:$roboelectric_version"
 }
 
 repositories {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
         android:name=".Applications.FreedomBoxApp"
         android:allowBackup="true"

--- a/app/src/main/java/org/freedombox/freedombox/Applications/FreedomBoxApp.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Applications/FreedomBoxApp.kt
@@ -20,9 +20,13 @@ import android.app.Application
 import org.freedombox.freedombox.Components.AppComponent
 import org.freedombox.freedombox.Components.DaggerAppComponent
 import org.freedombox.freedombox.Modules.AppModule
+import org.freedombox.freedombox.Utils.Connectivity.ConnectivityMonitor
+import javax.inject.Inject
 
 class FreedomBoxApp : Application() {
     lateinit var appComponent: AppComponent
+
+    @Inject lateinit var connectivityMonitor: ConnectivityMonitor
 
     override fun onCreate() {
         super.onCreate()
@@ -33,5 +37,6 @@ class FreedomBoxApp : Application() {
                 .build()
 
         appComponent.inject(this)
+        connectivityMonitor.init()
     }
 }

--- a/app/src/main/java/org/freedombox/freedombox/Modules/AppModule.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Modules/AppModule.kt
@@ -17,11 +17,12 @@
 package org.freedombox.freedombox.Modules
 
 import android.app.Application
-import android.content.Context
 import android.content.SharedPreferences
+import android.net.ConnectivityManager
 import android.preference.PreferenceManager
 import dagger.Module
 import dagger.Provides
+import org.freedombox.freedombox.Utils.Connectivity.ConnectivityMonitor
 import javax.inject.Singleton
 
 @Module class AppModule(val application: Application) {
@@ -29,4 +30,9 @@ import javax.inject.Singleton
     @Singleton
     fun provideSharedPreferences(): SharedPreferences = PreferenceManager
             .getDefaultSharedPreferences(application.applicationContext)
+
+    @Provides
+    @Singleton
+    fun provideConnectivityMonitor(): ConnectivityMonitor =
+            ConnectivityMonitor(application.applicationContext)
 }

--- a/app/src/main/java/org/freedombox/freedombox/Utils/Connectivity/ConnectivityMonitor.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Utils/Connectivity/ConnectivityMonitor.kt
@@ -1,0 +1,61 @@
+/* This file is part of FreedomBox.
+ *
+ * FreedomBox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * FreedomBox is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with FreedomBox. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.freedombox.freedombox.Utils.Connectivity
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+
+class ConnectivityMonitor(val applicationContext: Context) {
+    private val connectivityManager: ConnectivityManager = applicationContext
+            .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val subscribers = mutableListOf<(Boolean) -> Unit>()
+
+    private val networkReceiver: BroadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent?) {
+            notifySubscribers(isNetworkConnected())
+        }
+    }
+
+    fun init() {
+        val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
+        applicationContext.registerReceiver(networkReceiver, intentFilter)
+    }
+
+    fun subscribe(subscriber: (Boolean) -> Unit) {
+        if (!subscribers.contains(subscriber))
+            subscribers.add(subscriber)
+    }
+
+    fun unSubscribe(subscriber: (Boolean) -> Unit) {
+        subscribers.remove(subscriber)
+    }
+
+    fun notifySubscribers(state: Boolean) {
+        subscribers.forEach {
+            it(state)
+        }
+    }
+
+    fun isNetworkConnected(): Boolean {
+        val info = connectivityManager.activeNetworkInfo
+        return info != null && info.isConnected
+    }
+}

--- a/app/src/main/java/org/freedombox/freedombox/Views/Fragments/BaseFragment.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Views/Fragments/BaseFragment.kt
@@ -17,13 +17,15 @@
 package org.freedombox.freedombox.Views.Fragments
 
 import android.os.Bundle
+import android.support.design.widget.Snackbar
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import org.freedombox.freedombox.Applications.FreedomBoxApp
 import org.freedombox.freedombox.Components.AppComponent
+import org.freedombox.freedombox.Views.IBaseView
 
-abstract class BaseFragment : android.support.v4.app.Fragment() {
+abstract class BaseFragment : android.support.v4.app.Fragment(), IBaseView {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -40,4 +42,12 @@ abstract class BaseFragment : android.support.v4.app.Fragment() {
     protected abstract fun getLayoutId(): Int
 
     protected abstract fun injectFragment(appComponent: AppComponent)
+
+    override fun showSnackMessage(message: String, duration: Int) {
+        Snackbar.make(
+                activity.findViewById(android.R.id.content),
+                message,
+                duration
+        ).show()
+    }
 }

--- a/app/src/main/java/org/freedombox/freedombox/Views/Fragments/SplashFragment.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Views/Fragments/SplashFragment.kt
@@ -22,10 +22,13 @@ import android.widget.Toast
 import kotlinx.android.synthetic.main.fragment_splash.*
 import org.freedombox.freedombox.Components.AppComponent
 import org.freedombox.freedombox.R
+import org.freedombox.freedombox.Utils.Connectivity.ConnectivityMonitor
 import javax.inject.Inject
 
 class SplashFragment : BaseFragment() {
     @Inject lateinit var sharedPreferences: SharedPreferences
+
+    @Inject lateinit var connectivityMonitor: ConnectivityMonitor
 
     override fun getLayoutId() = R.layout.fragment_splash
 

--- a/app/src/main/java/org/freedombox/freedombox/Views/IBaseView.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Views/IBaseView.kt
@@ -14,19 +14,8 @@
  * along with FreedomBox. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.freedombox.freedombox
+package org.freedombox.freedombox.Views
 
-import org.junit.Test
-
-import org.junit.Assert.*
-
-/**
- * To work on unit tests, switch the Test Artifact in the Build Variants view.
- */
-class ExampleUnitTest {
-    @Test
-    @Throws(Exception::class)
-    fun addition_isCorrect() {
-        assertEquals(4, (2 + 2).toLong())
-    }
+interface IBaseView {
+    fun showSnackMessage(message: String, duration: Int)
 }

--- a/app/src/test/java/org/freedombox/freedombox/Utils/Connectivity/ConnectivityMonitorTest.kt
+++ b/app/src/test/java/org/freedombox/freedombox/Utils/Connectivity/ConnectivityMonitorTest.kt
@@ -1,0 +1,45 @@
+/* This file is part of FreedomBox.
+ *
+ * FreedomBox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * FreedomBox is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with FreedomBox. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.freedombox.freedombox.Utils.Connectivity
+
+import android.content.Intent
+import android.net.ConnectivityManager
+import junit.framework.Assert
+import org.freedombox.freedombox.BuildConfig
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment.application
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class)
+class ConnectivityMonitorTest {
+
+    @Test
+    fun testSubscriber() {
+        val monitor = ConnectivityMonitor(application.applicationContext)
+
+        monitor.init()
+        monitor.subscribe {
+            Assert.assertTrue(true)
+        }
+
+        val intent = Intent(ConnectivityManager.CONNECTIVITY_ACTION)
+        application.sendBroadcast(intent)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     ext {
         kotlin_version = '1.1.3-2'
         dagger_version = '2.11'
-        roboelectric_version = '3.3.2'
+        robolectric_version = '3.3.2'
         supportlib_version = '25.3.1'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ buildscript {
     ext {
         kotlin_version = '1.1.3-2'
         dagger_version = '2.11'
+        roboelectric_version = '3.3.2'
+        supportlib_version = '25.3.1'
     }
 
     repositories {


### PR DESCRIPTION
Changed:
- Add a connectivity monitor which notifies subscribers of network change
- Add Robolectric framework to ease out Unit Tests
- Add Snackbar to display semi-important notices
- Add tests

This can be used as follows:
- In any Fragment, inject as follows:
```kotlin
@Inject lateinit var connectivityMonitor: ConnectivityMonitor
```
- Register callbacks (for example showing snackbars) as follows:
```kotlin
connectivityMonitor.subscribe { connected ->
    if (connected) {
        showSnackMessage("Network Connected.", Snackbar.LENGTH_SHORT)
    } else {
        showSnackMessage("Network Disconnected!", Snackbar.LENGTH_SHORT)
    }
}
```