### PR TITLE
Fix all license header with Java standards

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/androidTest/java/org/freedombox/freedombox/ApplicationTest.kt
+++ b/app/src/androidTest/java/org/freedombox/freedombox/ApplicationTest.kt
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main/java/org/freedombox/freedombox/Applications/FreedomBoxApp.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Applications/FreedomBoxApp.kt
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main/java/org/freedombox/freedombox/Components/AppComponent.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Components/AppComponent.kt
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main/java/org/freedombox/freedombox/Modules/AppModule.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Modules/AppModule.kt
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main/java/org/freedombox/freedombox/Utils/Connectivity/ConnectivityMonitor.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Utils/Connectivity/ConnectivityMonitor.kt
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main/java/org/freedombox/freedombox/Views/Activities/BaseActivity.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Views/Activities/BaseActivity.kt
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main/java/org/freedombox/freedombox/Views/Activities/MainActivity.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Views/Activities/MainActivity.kt
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main/java/org/freedombox/freedombox/Views/Fragments/BaseFragment.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Views/Fragments/BaseFragment.kt
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main/java/org/freedombox/freedombox/Views/Fragments/SplashFragment.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Views/Fragments/SplashFragment.kt
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main/java/org/freedombox/freedombox/Views/IBaseView.kt
+++ b/app/src/main/java/org/freedombox/freedombox/Views/IBaseView.kt
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/test/java/org/freedombox/freedombox/Utils/Connectivity/ConnectivityMonitorTest.kt
+++ b/app/src/test/java/org/freedombox/freedombox/Utils/Connectivity/ConnectivityMonitorTest.kt
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
-/* This file is part of FreedomBox.
+/**
+ * This file is part of FreedomBox.
  *
  * FreedomBox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This fixes the license header format of all the Kotlin/Gradle files to conform to the Standard Java standards thereby allowing tools like IntelliJ to interpret/edit them correctly.